### PR TITLE
public_ip now looks for ens NICs

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -148,6 +148,9 @@ function public_ip {
         ip=$(get_inet_addr eth)
     fi
     if [[ "$ip" == "" || "$ip" == "not found" ]]; then
+        ip=$(get_inet_addr ens)
+    fi
+    if [[ "$ip" == "" || "$ip" == "not found" ]]; then
         ip=$(get_inet_addr venet0)
     fi
     if [[ "$ip" == "" || "$ip" == "not found" ]]; then


### PR DESCRIPTION
Ubuntu 16.04 in some cases uses ens not eth for NICs.

$ ip a | grep ens.*UP
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000